### PR TITLE
Update link to client repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Dixit
 
-A Dixit server written in Elixir, designed to work with the client written in Elm available at https://gitlab.com/NiavlysB/dixit-elm.
+A Dixit server written in Elixir, designed to work with the client written in Elm available at https://gitlab.com/sylbru/dixit-elm.


### PR DESCRIPTION
https://gitlab.com/NiavlysB/dixit-elm moved to https://gitlab.com/sylbru/dixit-elm.